### PR TITLE
Fix: removeItem not removing from filteredProducts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ function App() {
 
   const removeItem = (id) => {
     console.log(id)
-    setFilteredProducts(products.filter((product) => product.id != id))
+    setFilteredProducts(filteredProducts.filter((product) => product.id != id))
   }
 
   const filterMenOnly = () => {


### PR DESCRIPTION
`removeItems` was removing items from the main `products` list instead of `filteredProducts`. This bug was also removing all previous filters. 
